### PR TITLE
Format 418 responses per the RFC

### DIFF
--- a/src/Teapot.Web/Models/StatusCodeResults.cs
+++ b/src/Teapot.Web/Models/StatusCodeResults.cs
@@ -174,7 +174,7 @@ namespace Teapot.Web.Models
                          });
             Add(418, new StatusCodeResult
                          {
-                             Description = "I'm a Teapot",
+                             Description = "I'm a teapot",
                              Link = new Uri("http://www.ietf.org/rfc/rfc2324.txt")
                          });
             Add(500, new StatusCodeResult


### PR DESCRIPTION
RFC 2324 specifies that the 418 error code conforms to "I'm a teapot",
with a lowercase letter T. This commit corrects the deficiency in the
current implementation, which featured an uppercase T.

Signed-off-by: Eugene E. Kashpureff Jr eugene@khresear.ch
