### PR TITLE
Add support for suppressing response body via parameter

### DIFF
--- a/src/Teapot.Web.Tests/IntegrationTests/StatusCodeTests.cs
+++ b/src/Teapot.Web.Tests/IntegrationTests/StatusCodeTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc.Testing;
+using Teapot.Web.Controllers;
 
 namespace Teapot.Web.Tests.IntegrationTests;
 
@@ -28,6 +29,41 @@ public class StatusCodeTests
             Assert.That(response.Content?.Headers?.ContentType, Is.Not.Null);
             Assert.That(response.Content?.Headers?.ContentType?.MediaType, Is.EqualTo("text/plain"));
             Assert.That(response.Content?.Headers?.ContentLength, Is.EqualTo(body.Length));
+        });
+    }
+
+    [TestCaseSource(typeof(TestCases), nameof(TestCases.StatusCodesWithContent))]
+    public async Task ResponseWithContentSuppressedViaQs([Values] TestCase testCase)
+    {
+        var uri = $"/{testCase.Code}?{nameof(CustomHttpStatusCodeResult.SuppressBody)}=true";
+        using var httpRequest = new HttpRequestMessage(_httpMethod, uri);
+        using var response = await _httpClient.SendAsync(httpRequest);
+        Assert.That((int)response.StatusCode, Is.EqualTo(testCase.Code));
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Multiple(() =>
+        {
+            Assert.That(body, Is.Empty);
+            Assert.That(response.Content?.Headers?.ContentType, Is.Null);
+            Assert.That(response.Content?.Headers?.ContentType?.MediaType, Is.Null);
+            Assert.That(response.Content?.Headers?.ContentLength, Is.EqualTo(0));
+        });
+    }
+
+    [TestCaseSource(typeof(TestCases), nameof(TestCases.StatusCodesWithContent))]
+    public async Task ResponseWithContentSuppressedViaHeader([Values] TestCase testCase)
+    {
+        var uri = $"/{testCase.Code}";
+        using var httpRequest = new HttpRequestMessage(_httpMethod, uri);
+        httpRequest.Headers.Add(StatusController.SUPPRESS_BODY_HEADER, "true");
+        using var response = await _httpClient.SendAsync(httpRequest);
+        Assert.That((int)response.StatusCode, Is.EqualTo(testCase.Code));
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Multiple(() =>
+        {
+            Assert.That(body, Is.Empty);
+            Assert.That(response.Content?.Headers?.ContentType, Is.Null);
+            Assert.That(response.Content?.Headers?.ContentType?.MediaType, Is.Null);
+            Assert.That(response.Content?.Headers?.ContentLength, Is.EqualTo(0));
         });
     }
 

--- a/src/Teapot.Web.Tests/UnitTests/CustomHttpStatusCodeResultTests.cs
+++ b/src/Teapot.Web.Tests/UnitTests/CustomHttpStatusCodeResultTests.cs
@@ -50,7 +50,7 @@ public class CustomHttpStatusCodeResultTests
             Description = testCase.Description
         };
 
-        var target = new CustomHttpStatusCodeResult(testCase.Code, statusCodeResult, null, new());
+        var target = new CustomHttpStatusCodeResult(testCase.Code, statusCodeResult, null, null, new());
 
         await target.ExecuteResultAsync(_mockActionContext.Object);
         Assert.Multiple(() => {
@@ -74,7 +74,7 @@ public class CustomHttpStatusCodeResultTests
             Description = testCase.Description
         };
 
-        var target = new CustomHttpStatusCodeResult(testCase.Code, statusCodeResult, null, new());
+        var target = new CustomHttpStatusCodeResult(testCase.Code, statusCodeResult, null, null, new());
 
         _httpContext.Request.Headers.Accept = "application/json";
 
@@ -105,7 +105,7 @@ public class CustomHttpStatusCodeResultTests
         _httpContext.Response.Headers["Content-Type"] = "text/plain";
         _httpContext.Response.Headers["Content-Length"] = "42";
 
-        var target = new CustomHttpStatusCodeResult(testCase.Code, statusCodeResult, null, new());
+        var target = new CustomHttpStatusCodeResult(testCase.Code, statusCodeResult, null, null, new());
 
         await target.ExecuteResultAsync(_mockActionContext.Object);
         Assert.Multiple(() => {

--- a/src/Teapot.Web.Tests/UnitTests/SleepTests.cs
+++ b/src/Teapot.Web.Tests/UnitTests/SleepTests.cs
@@ -31,7 +31,7 @@ public class SleepTests {
             }
         };
 
-        IActionResult result = controller.StatusCode(200, Sleep);
+        IActionResult result = controller.StatusCode(200, Sleep, null);
 
         Assert.Multiple(() => {
             Assert.That(result, Is.InstanceOf<CustomHttpStatusCodeResult>());
@@ -50,7 +50,7 @@ public class SleepTests {
         };
         controller.ControllerContext.HttpContext.Request.Headers.Add(StatusController.SLEEP_HEADER, Sleep.ToString());
 
-        IActionResult result = controller.StatusCode(200, null);
+        IActionResult result = controller.StatusCode(200, null, null);
 
         Assert.Multiple(() => {
             Assert.That(result, Is.InstanceOf<CustomHttpStatusCodeResult>());
@@ -69,7 +69,7 @@ public class SleepTests {
         };
         controller.ControllerContext.HttpContext.Request.Headers.Add(StatusController.SLEEP_HEADER, Sleep.ToString());
 
-        IActionResult result = controller.StatusCode(200, Sleep * 2);
+        IActionResult result = controller.StatusCode(200, Sleep * 2, null);
 
         Assert.Multiple(() => {
             Assert.That(result, Is.InstanceOf<CustomHttpStatusCodeResult>());
@@ -88,7 +88,7 @@ public class SleepTests {
         };
         controller.ControllerContext.HttpContext.Request.Headers.Add(StatusController.SLEEP_HEADER, "invalid");
 
-        IActionResult result = controller.StatusCode(200, null);
+        IActionResult result = controller.StatusCode(200, null, null);
 
         Assert.Multiple(() => {
             Assert.That(result, Is.InstanceOf<CustomHttpStatusCodeResult>());

--- a/src/Teapot.Web.Tests/UnitTests/SuppressBodyTests.cs
+++ b/src/Teapot.Web.Tests/UnitTests/SuppressBodyTests.cs
@@ -1,0 +1,132 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Teapot.Web.Controllers;
+using Teapot.Web.Models;
+using Teapot.Web.Models.Unofficial;
+
+namespace Teapot.Web.Tests.UnitTests;
+public class SuppressBodyTests {
+    private TeapotStatusCodeResults _statusCodes;
+
+    [SetUp]
+    public void Setup() {
+        _statusCodes = new(
+            new AmazonStatusCodeResults(),
+            new CloudflareStatusCodeResults(),
+            new EsriStatusCodeResults(),
+            new LaravelStatusCodeResults(),
+            new MicrosoftStatusCodeResults(),
+            new NginxStatusCodeResults(),
+            new TwitterStatusCodeResults()
+        );
+    }
+
+    [Test]
+    [TestCase(true)]
+    [TestCase(false)]
+    [TestCase(null)]
+    public void SuppressBodyReadFromQuery(bool? suppressBody) {
+        StatusController controller = new(_statusCodes) {
+            ControllerContext = new ControllerContext {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+
+        IActionResult result = controller.StatusCode(200, null, suppressBody);
+
+        Assert.Multiple(() => {
+            Assert.That(result, Is.InstanceOf<CustomHttpStatusCodeResult>());
+
+            CustomHttpStatusCodeResult r = (CustomHttpStatusCodeResult)result;
+            Assert.That(r.SuppressBody, Is.EqualTo(suppressBody));
+        });
+    }
+
+    [Test]
+    [TestCase("true")]
+    [TestCase("false")]
+    [TestCase("")]
+    public void SuppressBodyReadFromHeader(string? suppressBody)
+    {
+        StatusController controller = new(_statusCodes)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+        controller.ControllerContext.HttpContext.Request.Headers.Add(StatusController.SUPPRESS_BODY_HEADER, suppressBody);
+
+        IActionResult result = controller.StatusCode(200, null, null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.InstanceOf<CustomHttpStatusCodeResult>());
+
+            CustomHttpStatusCodeResult r = (CustomHttpStatusCodeResult)result;
+            var expectedValue = suppressBody switch
+            {
+                string { Length: >0 } stringValue => (bool?)bool.Parse(stringValue),
+                _ => null
+            };
+            Assert.That(r.SuppressBody, Is.EqualTo(expectedValue));
+        });
+    }
+
+    [Test]
+    [TestCase("true", null)]
+    [TestCase("false", null)]
+    [TestCase("true", false)]
+    [TestCase("false", true)]
+    [TestCase("", true)]
+    [TestCase("", false)]
+    public void SuppressBodyReadFromQSTakesPriorityHeader(string? headerValue, bool? queryStringValue)
+    {
+        StatusController controller = new(_statusCodes)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+        controller.ControllerContext.HttpContext.Request.Headers.Add(StatusController.SUPPRESS_BODY_HEADER, headerValue);
+
+        IActionResult result = controller.StatusCode(200, null, queryStringValue);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.InstanceOf<CustomHttpStatusCodeResult>());
+            
+            CustomHttpStatusCodeResult r = (CustomHttpStatusCodeResult)result;
+            var expectedValue = queryStringValue.HasValue ? queryStringValue.Value : headerValue switch
+            {
+                string { Length: > 0 } stringValue => (bool?)bool.Parse(stringValue),
+                _ => null
+            };
+            Assert.That(r.SuppressBody, Is.EqualTo(expectedValue));
+        });
+    }
+
+    [Test]
+    public void BadSuppressBodyHeaderIgnored()
+    {
+        StatusController controller = new(_statusCodes)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+        controller.ControllerContext.HttpContext.Request.Headers.Add(StatusController.SUPPRESS_BODY_HEADER, "invalid");
+
+        IActionResult result = controller.StatusCode(200, null, null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.InstanceOf<CustomHttpStatusCodeResult>());
+
+            CustomHttpStatusCodeResult r = (CustomHttpStatusCodeResult)result;
+            Assert.That(r.SuppressBody, Is.Null);
+        });
+    }
+}

--- a/src/Teapot.Web.Tests/UnitTests/SuppressBodyTests.cs
+++ b/src/Teapot.Web.Tests/UnitTests/SuppressBodyTests.cs
@@ -26,8 +26,10 @@ public class SuppressBodyTests {
     [TestCase(false)]
     [TestCase(null)]
     public void SuppressBodyReadFromQuery(bool? suppressBody) {
-        StatusController controller = new(_statusCodes) {
-            ControllerContext = new ControllerContext {
+        StatusController controller = new(_statusCodes)
+        {
+            ControllerContext = new ControllerContext
+            {
                 HttpContext = new DefaultHttpContext()
             }
         };

--- a/src/Teapot.Web/CustomHttpStatusCodeResult.cs
+++ b/src/Teapot.Web/CustomHttpStatusCodeResult.cs
@@ -18,14 +18,18 @@ public class CustomHttpStatusCodeResult : StatusCodeResult {
 
     private readonly TeapotStatusCodeResult _statusCodeResult;
     private readonly int? _sleep;
+    private readonly bool? _suppressBody;
     private readonly Dictionary<string, StringValues> _customResponseHeaders;
 
     public int? Sleep => _sleep;
 
-    public CustomHttpStatusCodeResult([ActionResultStatusCode] int statusCode, TeapotStatusCodeResult statusCodeResult, int? sleep, Dictionary<string, StringValues> customResponseHeaders)
+    public bool? SuppressBody => _suppressBody;
+
+    public CustomHttpStatusCodeResult([ActionResultStatusCode] int statusCode, TeapotStatusCodeResult statusCodeResult, int? sleep, bool? suppressBody, Dictionary<string, StringValues> customResponseHeaders)
         : base(statusCode) {
         _statusCodeResult = statusCodeResult;
         _sleep = sleep;
+        _suppressBody = suppressBody;
         _customResponseHeaders = customResponseHeaders;
     }
 
@@ -51,7 +55,7 @@ public class CustomHttpStatusCodeResult : StatusCodeResult {
             context.HttpContext.Response.Headers.Add(header, values);
         }
 
-        if (_statusCodeResult.ExcludeBody) {
+        if (_statusCodeResult.ExcludeBody || _suppressBody == true) {
             //remove Content-Length and Content-Type when there isn't any body
             context.HttpContext.Response.Headers.Remove("Content-Length");
             context.HttpContext.Response.Headers.Remove("Content-Type");


### PR DESCRIPTION
Adds supporting for suppressing the response body for status codes, that would otherwise include one, via a querystring parameter or header value.

Fixes #132