### PR TITLE
Request parameters and headers to change the behaviour of the 429 Too Many Requests response.

### DIFF
--- a/src/Teapot.Web.Tests/UnitTests/RequestSpecificHeaderTests/Status429Tests.cs
+++ b/src/Teapot.Web.Tests/UnitTests/RequestSpecificHeaderTests/Status429Tests.cs
@@ -1,0 +1,207 @@
+﻿using System.Globalization;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Microsoft.VisualBasic;
+
+using Teapot.Web.Models;
+using Teapot.Web.Models.Unofficial;
+
+namespace Teapot.Web.Tests.UnitTests.RequestSpecificHeaderTests;
+internal class Status429Tests
+{
+    private TeapotStatusCodeResults _statusCodes;
+    private TeapotStatusCodeResult _tooManyRequestsCodeResult { get => _statusCodes[429]; }
+
+    private string _dateFormat = @"ddd, dd MMM yyyy HH:mm:ss \G\M\T";
+    private CultureInfo _enGbCulture = CultureInfo.GetCultureInfo("en-GB");
+
+    [SetUp]
+    public void Setup()
+    {
+        _statusCodes = new(
+            new AmazonStatusCodeResults(),
+            new CloudflareStatusCodeResults(),
+            new EsriStatusCodeResults(),
+            new LaravelStatusCodeResults(),
+            new MicrosoftStatusCodeResults(),
+            new NginxStatusCodeResults(),
+            new TwitterStatusCodeResults()
+        );
+    }
+
+    [Test]
+    public void GetRequestSpecificHeadersDefined()
+    {
+        Assert.IsNotNull(_tooManyRequestsCodeResult.GetRequestSpecificHeaders);
+    }
+
+    [Test]
+    public void DefaultHeaders()
+    {
+        var queryCollection = new QueryCollection();
+        var headers = new HeaderDictionary();
+
+        var expected = new Dictionary<string, string>()
+        {
+            { "Retry-After", "5" }
+        };
+
+        Assert.IsNotNull(_tooManyRequestsCodeResult.GetRequestSpecificHeaders);
+        var actual = _tooManyRequestsCodeResult.GetRequestSpecificHeaders(queryCollection, headers);
+
+        foreach (var kvp in expected)
+        {
+            Assert.That(actual, Contains.Key(kvp.Key));
+            Assert.That(actual[kvp.Key], Is.EqualTo(kvp.Value));
+        }
+    }
+
+    [Test]
+    [TestCase("", "5")]
+    [TestCase("0", "0")]
+    [TestCase("5", "5")]
+    [TestCase("10", "10")]
+    [TestCase("100000", "100000")]
+    public void SecondsQuery(string secondsQuery, string secondsExpected)
+    {
+        var queryCollection = new QueryCollection(new Dictionary<string, StringValues>()
+        {
+            {"seconds", new StringValues(secondsQuery) }
+        });
+        var headers = new HeaderDictionary();
+
+        var expected = new Dictionary<string, string>()
+        {
+            { "Retry-After", secondsExpected }
+        };
+
+        Assert.IsNotNull(_tooManyRequestsCodeResult.GetRequestSpecificHeaders);
+        var actual = _tooManyRequestsCodeResult.GetRequestSpecificHeaders(queryCollection, headers);
+
+        foreach (var kvp in expected)
+        {
+            Assert.That(actual, Contains.Key(kvp.Key));
+            Assert.That(actual[kvp.Key], Is.EqualTo(kvp.Value));
+        }
+    }
+
+    [Test]
+    [TestCase("", "5")]
+    [TestCase("0", "0")]
+    [TestCase("5", "5")]
+    [TestCase("10", "10")]
+    [TestCase("100000", "100000")]
+    public void SecondsHeader(string secondsHeader, string secondsExpected)
+    {
+        var queryCollection = new QueryCollection();
+        var headers = new HeaderDictionary(new Dictionary<string, StringValues>()
+        {
+            { "X-Retry-After-Seconds", secondsHeader }
+        });
+
+        var expected = new Dictionary<string, string>()
+        {
+            { "Retry-After", secondsExpected }
+        };
+
+        Assert.IsNotNull(_tooManyRequestsCodeResult.GetRequestSpecificHeaders);
+        var actual = _tooManyRequestsCodeResult.GetRequestSpecificHeaders(queryCollection, headers);
+
+        foreach (var kvp in expected)
+        {
+            Assert.That(actual, Contains.Key(kvp.Key));
+            Assert.That(actual[kvp.Key], Is.EqualTo(kvp.Value));
+        }
+    }
+
+    [Test]
+    public void SecondsFormatQuery()
+    {
+        var queryCollection = new QueryCollection(new Dictionary<string, StringValues>()
+        {
+            {"format", new StringValues("seconds") }
+        });
+        var headers = new HeaderDictionary();
+
+        var expected = new Dictionary<string, string>()
+        {
+            { "Retry-After", "5" }
+        };
+
+        Assert.IsNotNull(_tooManyRequestsCodeResult.GetRequestSpecificHeaders);
+        var actual = _tooManyRequestsCodeResult.GetRequestSpecificHeaders(queryCollection, headers);
+
+        foreach (var kvp in expected)
+        {
+            Assert.That(actual, Contains.Key(kvp.Key));
+            Assert.That(actual[kvp.Key], Is.EqualTo(kvp.Value));
+        }
+    }
+
+    [Test]
+    public void SecondsFormatHeader()
+    {
+        var queryCollection = new QueryCollection();
+        var headers = new HeaderDictionary(new Dictionary<string, StringValues>()
+        {
+            {"X-Retry-After-Format", new StringValues("seconds") }
+        });
+
+        var expected = new Dictionary<string, string>()
+        {
+            { "Retry-After", "5" }
+        };
+
+        Assert.IsNotNull(_tooManyRequestsCodeResult.GetRequestSpecificHeaders);
+        var actual = _tooManyRequestsCodeResult.GetRequestSpecificHeaders(queryCollection, headers);
+
+        foreach (var kvp in expected)
+        {
+            Assert.That(actual, Contains.Key(kvp.Key));
+            Assert.That(actual[kvp.Key], Is.EqualTo(kvp.Value));
+        }
+    }
+
+    [Test]
+    public void DateFormatQuery()
+    {
+        var queryCollection = new QueryCollection(new Dictionary<string, StringValues>()
+        {
+            {"format", new StringValues("date") }
+        });
+        var headers = new HeaderDictionary();
+
+        var expectedDate = DateTime.UtcNow.AddSeconds(5);
+
+        Assert.IsNotNull(_tooManyRequestsCodeResult.GetRequestSpecificHeaders);
+        var actual = _tooManyRequestsCodeResult.GetRequestSpecificHeaders(queryCollection, headers);
+
+        Assert.That(actual, Contains.Key("Retry-After"));
+
+        var actualValue = actual["Retry-After"];
+        var actualDate = DateTime.ParseExact(actualValue, _dateFormat, _enGbCulture);
+        Assert.That(actualDate, Is.EqualTo(expectedDate).Within(1).Seconds);
+    }
+
+    [Test]
+    public void DateFormatHeader()
+    {
+        var queryCollection = new QueryCollection();
+        var headers = new HeaderDictionary(new Dictionary<string, StringValues>()
+        {
+            {"X-Retry-After-Format", new StringValues("date") }
+        });
+
+        var expectedDate = DateTime.UtcNow.AddSeconds(5);
+
+        Assert.IsNotNull(_tooManyRequestsCodeResult.GetRequestSpecificHeaders);
+        var actual = _tooManyRequestsCodeResult.GetRequestSpecificHeaders(queryCollection, headers);
+
+        Assert.That(actual, Contains.Key("Retry-After"));
+
+        var actualValue = actual["Retry-After"];
+        var actualDate = DateTime.ParseExact(actualValue, _dateFormat, _enGbCulture);
+        Assert.That(actualDate, Is.EqualTo(expectedDate).Within(1).Seconds);
+    }
+}

--- a/src/Teapot.Web/Models/TeapotStatusCodeResult.cs
+++ b/src/Teapot.Web/Models/TeapotStatusCodeResult.cs
@@ -14,6 +14,8 @@ public class TeapotStatusCodeResult
     public string? Body { get; set; }
     public bool IsNonStandard { get; init; }
     public GetRequestSpecificHeaders? GetRequestSpecificHeaders { get; init; }
+    public Dictionary<string, string>? RequestParameters { get; init; }
+    public Dictionary<string, string>? RequestHeaders { get; init; }
 }
 
 public delegate IDictionary<string, string> GetRequestSpecificHeaders(IQueryCollection query, IHeaderDictionary requestHeaders);

--- a/src/Teapot.Web/Models/TeapotStatusCodeResult.cs
+++ b/src/Teapot.Web/Models/TeapotStatusCodeResult.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 
+using Microsoft.AspNetCore.Http;
+
 namespace Teapot.Web.Models;
 
 public class TeapotStatusCodeResult
@@ -11,4 +13,7 @@ public class TeapotStatusCodeResult
     public Uri? Link { get; set; }
     public string? Body { get; set; }
     public bool IsNonStandard { get; init; }
+    public GetRequestSpecificHeaders? GetRequestSpecificHeaders { get; init; }
 }
+
+public delegate IDictionary<string, string> GetRequestSpecificHeaders(IQueryCollection query, IHeaderDictionary requestHeaders);

--- a/src/Teapot.Web/Models/TeapotStatusCodeResults.cs
+++ b/src/Teapot.Web/Models/TeapotStatusCodeResults.cs
@@ -308,7 +308,7 @@ public class TeapotStatusCodeResults : Dictionary<int, TeapotStatusCodeResult>
 
                 string retryAfter;
 
-                if("date".Equals(format, StringComparison.InvariantCultureIgnoreCase)) //Date format: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date
+                if ("date".Equals(format, StringComparison.InvariantCultureIgnoreCase)) //Date format: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date
                     retryAfter = DateTime.UtcNow.AddSeconds(retryAfterSeconds).ToString(@"ddd, dd MMM yyyy HH:mm:ss \G\M\T", System.Globalization.CultureInfo.GetCultureInfo("en-GB"));
                 else
                     retryAfter = retryAfterSeconds.ToString();
@@ -316,6 +316,14 @@ public class TeapotStatusCodeResults : Dictionary<int, TeapotStatusCodeResult>
                 responseHeaders.Add("Retry-After", retryAfter);
 
                 return responseHeaders;
+            },
+            RequestParameters = new Dictionary<string, string> {
+                { "seconds", "The number of seconds to be specified in the Retry-After reponse header. Default 5." },
+                { "format", "The format of the Retry-After response header. Accepted values are \"seconds\" and \"date\". Default \"seconds\"." }
+            },
+            RequestHeaders = new Dictionary<string, string> {
+                { "X-Retry-After-Seconds", "The number of seconds to be specified in the Retry-After reponse header. Default 5." },
+                { "X-Retry-After-Format", "The format of the Retry-After response header. Accepted values are \"seconds\" and \"date\". Default \"seconds\"." }
             }
         });
         Add(431, new TeapotStatusCodeResult

--- a/src/Teapot.Web/Views/Status/Index.cshtml
+++ b/src/Teapot.Web/Views/Status/Index.cshtml
@@ -42,16 +42,43 @@
 
 <p>Here are all the codes we support (and any special notes):</p>
 <dl>
-    @foreach ((int statusCode, TeapotStatusCodeResult result) in Model.OrderBy(x => x.Value.IsNonStandard).ThenBy(x => x.Key)) {
+    @foreach ((int statusCode, TeapotStatusCodeResult result) in Model.OrderBy(x => x.Value.IsNonStandard).ThenBy(x => x.Key))
+    {
         <dt>@Html.RouteLink(statusCode.ToString(), "StatusCode", new { statusCode })</dt>
         <dd>
-            @if (result.Link is not null) {
+            @if (result.Link is not null)
+            {
                 <a href="@result.Link" target="_blank" title="@result.Description">@result.Description@(result.IsNonStandard ? " (non-standard status code)" : "")</a>
             }
-            else {
+            else
+            {
                 @result.Description
 
                 @(result.IsNonStandard ? " (non-standard status code)" : "")
+            }
+            <br />
+            @if (result.RequestParameters is not null)
+            {
+                <span>Request Parmaters</span>
+                <dl>
+                    @foreach(var kvp in result.RequestParameters)
+                    {
+                        <dt><code>@kvp.Key</code></dt>
+                        <dd>@kvp.Value</dd>
+                    }
+                </dl>
+            }
+
+            @if (result.RequestHeaders is not null)
+            {
+                <span>Request Headers</span>
+                <dl>
+                    @foreach (var kvp in result.RequestHeaders)
+                    {
+                        <dt><code>@kvp.Key</code></dt>
+                        <dd>@kvp.Value</dd>
+                    }
+                </dl>
             }
         </dd>
     }

--- a/src/Teapot.Web/wwwroot/css/main.css
+++ b/src/Teapot.Web/wwwroot/css/main.css
@@ -89,20 +89,23 @@ strong {
 }
 
 #view dl {
-    width: 100%;
+    display: grid;
+    grid-template-columns: max-content;
     overflow: hidden;
     margin-left: 30px;
 }
 
     #view dl dt {
-        float: left;
-        clear: left;
+        grid-column-start: 1;
     }
 
     #view dl dd {
-        float: left;
+        grid-column-start: 2;
         margin-left: 10px;
     }
+        #view dl dd code {
+            margin-left: 0;
+        }
 
         #view dl dd.note {
             clear: left;


### PR DESCRIPTION
This PR adds two request parameters and headers which change the value of the response header `Retry-After` of the `429: Too Many Requests` response.

Parameter `seconds` / header `X-Retry-After-Seconds`
- Sets the number of seconds used for the `Retry-After` response header.
- Default: 5 seconds (same as existing implementation).

Parameter `format` / header `X-Retry-After-Format`:
- Sets the format of the `Retry-After` resonse header.
- Accepted values:
  - Any value returns a number of seconds
  - `date` returns the current time + `seconds` in the [HTTP Date format](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date).
- Default: seconds format (same as existing implementation).

Also includes tests and additional information on the home page detailing these parameters.