### PR TITLE
Fix adding location header in 302 Redirect Response #136

### DIFF
--- a/src/Teapot.Web.Tests/IntegrationTests/CustomHeaderTests.cs
+++ b/src/Teapot.Web.Tests/IntegrationTests/CustomHeaderTests.cs
@@ -24,4 +24,24 @@ public class CustomHeaderTests {
         Assert.That(values.First(), Is.EqualTo(headerValue));
     }
 
+
+    [Test]
+    public async Task Redirects302ToCorrectLocation() {
+        string uri = "/302";
+        string headerName = "Location";
+        string headerValue = "example.com";
+
+        using HttpRequestMessage request = new(HttpMethod.Get, uri);
+        request.Headers.Add($"{StatusController.CUSTOM_RESPONSE_HEADER_PREFIX}{headerName}", headerValue);
+
+        using var response = await _httpClient.SendAsync(request);
+
+        var headers = response.Headers;
+        Assert.That(headers.Contains(headerName), Is.True);
+        Assert.That(headers.TryGetValues(headerName, out var values), Is.True);
+        Assert.That(values, Is.Not.Null);
+        Assert.That(values.Count(), Is.EqualTo(1));
+        Assert.That(values.First(), Is.EqualTo(headerValue));
+    }
+
 }

--- a/src/Teapot.Web/CustomHttpStatusCodeResult.cs
+++ b/src/Teapot.Web/CustomHttpStatusCodeResult.cs
@@ -51,8 +51,19 @@ public class CustomHttpStatusCodeResult : StatusCodeResult {
             }
         }
 
-        foreach ((string header, StringValues values) in _customResponseHeaders) {
-            context.HttpContext.Response.Headers.Add(header, values);
+        foreach ((string header, StringValues values) in _customResponseHeaders)
+        {
+            if (string.Equals(header, "Set-Cookie", StringComparison.OrdinalIgnoreCase))
+            {
+                foreach (var value in values)
+                {
+                    context.HttpContext.Response.Headers.Append("Set-Cookie", value);
+                }
+            }
+            else
+            {
+                context.HttpContext.Response.Headers[header] = values;
+            }
         }
 
         if (_statusCodeResult.ExcludeBody || _suppressBody == true) {


### PR DESCRIPTION

This pull request addresses #136 issue where Location headers were being added to the response when performing a 302 redirect. The expected behaviour is to have the Location header with the correct redirection URL.

Changes:

- Modified the logic to set the Location header value directly using `Headers[header] = values`, ensuring that only the last value of the Location header is set in the response.
- Added a new test case Redirects302ToCorrectLocation in CustomHeaderTests to verify that the 302 redirect response contains Location header with the correct value.

